### PR TITLE
Update jaeger and otel collector

### DIFF
--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -6,12 +6,12 @@ services:
     image: jaegertracing/all-in-one:latest
     ports:
       - "16686:16686"
-      - "14268"
-      - "14250"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
 
 # Collector
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.61.0
+    image: otel/opentelemetry-collector-contrib:0.79.0
     command: ["--config=/etc/otel-config.yaml", ""]
     volumes:
       - ./otel-config.yaml:/etc/otel-config.yaml

--- a/src/otel-config.yaml
+++ b/src/otel-config.yaml
@@ -6,15 +6,15 @@ receivers: # specifies how data gets into the Collector
 processors: # processors are run on data between being received and being exported
   batch: # a batch span processor waits for a batch of spans before it exports them
 exporters: # where to export the traces
-  jaeger: # 1. to jaeger
-    endpoint: jaeger-all-in-one:14250
+  otlp/jaeger: # 1. to jaeger
+    endpoint: jaeger-all-in-one:4317
     tls:
       insecure: true
   logging: # 2. to the logging
-    loglevel: debug
+    verbosity: detailed
 service: # configure what components are enabled in the Collector
   pipelines: # A pipeline = a set of receivers + processors + exporters
     traces: # here we define a traces pipline (you can also define metrics or logs pipelines)
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, jaeger]
+      exporters: [logging, otlp/jaeger]


### PR DESCRIPTION
This PR applies the following changes:
* Update otel collector to latest (0.61 -> 0.79)
* Make use of built-in OTLP capabilities of jaeger (the jaeger exporter is deprecated)
* loglevel to verbosity (that has been changed in one of the most recent collector versions)